### PR TITLE
Make sure the SAS is treated as a URL parameter

### DIFF
--- a/AzureStorageMiddleware/AzureStorageMiddleware.swift
+++ b/AzureStorageMiddleware/AzureStorageMiddleware.swift
@@ -24,7 +24,7 @@ class AzureStorageMiddleware: MunkiMiddleware {
 
         var modifiedRequest = request
         if modifiedRequest.url.contains(azureEndpoint) {
-            modifiedRequest.url = modifiedRequest.url + sharedAccessSignature
+            modifiedRequest.url = modifiedRequest.url + "?" + sharedAccessSignature
         }
         return modifiedRequest
     }


### PR DESCRIPTION
This makes sure the SAS is constructed as a URL parameter by adding the `?` in there. 

This should probably be treated like a URL instead of a string, but its works.